### PR TITLE
Allow node v6 and above

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Nicholas Hwang <nhwang@hubspot.com>"
   ],
   "engines": {
-    "node": ">=6.2.2"
+    "node": ">=6"
   },
   "scripts": {
     "ava": "ava",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "Nicholas Hwang <nhwang@hubspot.com>"
   ],
   "engines": {
-    "node": ">=6.9"
+    "node": ">=6.2.2"
   },
   "scripts": {
     "ava": "ava",


### PR DESCRIPTION
Lowering the required version of node so more packages can use this.

Tried it out on my machine. There didn't seem to be any issues with the rules.

@geekjuice 