### PR TITLE
Add ignoreRestSiblings flag on no-unused-vars rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 npm-debug.log
 yarn-error.log
+/node_modules

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
     "glob": "7.1.1"
   },
   "peerDependencies": {
-    "babel-eslint": "7.1.x",
-    "eslint": "3.17.x",
-    "eslint-plugin-react": "6.10.x"
+    "babel-eslint": "^7.1.x",
+    "eslint": "^3.17.x",
+    "eslint-plugin-react": "^6.10.x"
   },
   "eslintConfig": {
     "extends": "hubspot/esnext",

--- a/rules/eslint/variables.js
+++ b/rules/eslint/variables.js
@@ -42,7 +42,8 @@ module.exports = {
     'no-unused-vars': ['error', {
       'vars': 'local',
       'args': 'after-used',
-      'caughtErrors': 'none'
+      'caughtErrors': 'none',
+      'ignoreRestSiblings': true
     }],
 
     // disallow use of variables before they are defined


### PR DESCRIPTION
This allows for a common pattern of omitting object keys via destructuring. This rule option became available in 3.17.0, and other workarounds to get the linter to ignore this pattern are quite annoying.