### PR TITLE
Add varsIgnorePattern to no-unused-vars rule

### DIFF
--- a/rules/eslint/variables.js
+++ b/rules/eslint/variables.js
@@ -42,7 +42,8 @@ module.exports = {
     'no-unused-vars': ['error', {
       'vars': 'local',
       'args': 'after-used',
-      'caughtErrors': 'none'
+      'caughtErrors': 'none',
+      'varsIgnorePattern': '^__'
     }],
 
     // disallow use of variables before they are defined


### PR DESCRIPTION
Follow-up to discussion at #4. We've been using with rule in the UIComponents project for several months now, with great success. I think it's time to deploy it HubSpot-wide.

### Before

```jsx
render() {
  const { className, ...rest } = _.omit(this.props, 'omittedProp');
  return (
    <div
      className={classNames(className, 'my-base-class')}
      {...rest}
    />
  );
}
```

### After

```jsx
render() {
  const { className,  omittedProp: __omittedProp, ...rest } = this.props;
  return (
    <div
      className={classNames(className, 'my-base-class')}
      {...rest}
    />
  );
}
```

The convention of naming the var `__${originalVarName}` is, of course, arbitrary.