### PR TITLE
Allow JSX components to have all-caps names

### DIFF
--- a/rules/plugins/react.js
+++ b/rules/plugins/react.js
@@ -107,7 +107,9 @@ module.exports = {
     'react/jsx-no-undef': 'error',
 
     // Enforce PascalCase for user-defined JSX components
-    'react/jsx-pascal-case': 'error',
+    'react/jsx-pascal-case': ['error', {
+      'allowAllCaps': true,
+    }],
 
     // Enforce props alphabetical sorting
     'react/jsx-sort-props': ['off', {


### PR DESCRIPTION
By default, the [`jsx-pascal-case` rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md) doesn't allow all-caps component names. In UIComponents we have a wrapper around `<hr>` simply named `<HR>`. This should, I think, be a perfectly valid name for a React component (certainly better than `<Hr>`!).

This PR keeps the Pascal-case rule but enables the `allowAllCaps` option.