### PR TITLE
Remove valid-jsdoc rule

### DIFF
--- a/rules/eslint/errors.js
+++ b/rules/eslint/errors.js
@@ -102,9 +102,6 @@ module.exports = {
     // disallow comparisons with the value NaN
     'use-isnan': 'error',
 
-    // ensure JSDoc comments are valid
-    'valid-jsdoc': 'error',
-
     // ensure that the results of typeof are compared against a valid string
     'valid-typeof': 'error'
   }


### PR DESCRIPTION
See #7.

`require-jsdoc` is off, so this rule only applies to comments of the form

```js
/**
 * Comment comment comment...
 */
```

Still, failing a build if such comments aren't valid JSDoc seems excessive. All versions of `eslint-config-hubspot` prior to 7.0.0 had this rule disabled (as does the latest `eslint-config-airbnb`), making it an impediment for some projects to update to the latest version.